### PR TITLE
Add epoll-backed io handle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: compile & run check
         run: |
-          cargo run --example server
+          cargo run --example simple-server
+          cargo run --example block_on
 
   test:
     name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,7 @@ futures-lite = "2.6.0"
 flume = "0.11.1"
 tracing = "0.1.41"
 thiserror = "2.0.11"
+mio = {version="1.0.3", features=["net", "os-ext", "os-poll"]}
+slab = {version="0.4.9"}
 imputio = { path = "./imputio"}
 imputio-utils= {path="./imputio-utils"}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,8 +11,8 @@ tracing.workspace=true
 thiserror.workspace=true
 imputio-utils.workspace=true
 imputio.workspace=true
+mio.workspace=true
 tracing-subscriber = { version="0.3.0", features=["env-filter"]}
-mio = {version="1.0.3", features=["net", "os-poll"]}
 
 [features]
 delay-delete=["imputio-utils/delay-delete"]
@@ -26,5 +26,9 @@ name = "block_on"
 path = "./block_on/main.rs"
 
 [[example]]
-name = "server"
-path = "./server/main.rs"
+name = "tcp-server"
+path = "./server/tcp-server/main.rs"
+
+[[example]]
+name = "simple-server"
+path = "./server/simple/main.rs"

--- a/examples/server/tcp-server/main.rs
+++ b/examples/server/tcp-server/main.rs
@@ -1,0 +1,89 @@
+//! Example of a simple TCP server
+
+use std::io::{Read, Write};
+
+use flume::TryRecvError;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+use imputio::{Executor, ImputioRuntime};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 3456)).unwrap();
+
+    let (shutdown_tx, shutdown_rx) = flume::unbounded();
+    let (notify_tx, notify_rx) = flume::unbounded();
+
+    let listen_clone = listener.try_clone()?;
+
+    let rx = shutdown_rx.clone();
+    let mut rt = ImputioRuntime::<Executor>::new()
+        .with_tcp_listeners(vec![(listener, Some(notify_tx))])
+        .with_shutdown_notifier(shutdown_tx, rx);
+    rt.run();
+
+    loop {
+        // block waiting for event to be returned from io poller
+        let event = notify_rx.recv().inspect_err(|e| {
+            tracing::error!("Error receiving {e:}");
+        })?;
+
+        if event.is_write_closed() || event.is_read_closed() {
+            tracing::info!("WriteClosed or ReadClosed");
+            break;
+        } else {
+            let mut buffer = [0u8; 1024];
+            let mut data: Vec<u8> = vec![];
+
+            let (mut stream, sock_addr) = listen_clone.accept()?;
+            tracing::info!("SocketAddr: {:?}", sock_addr);
+
+            if event.is_readable() {
+                loop {
+                    match stream.read(&mut buffer) {
+                        Ok(n) if n > 0 => {
+                            data.extend_from_slice(&buffer[..n]);
+                        }
+                        Ok(_) => {
+                            break;
+                        }
+                        Err(ref e) => {
+                            if e.kind() != std::io::ErrorKind::WouldBlock {
+                                tracing::error!("Error {e:}");
+                            }
+                            break;
+                        }
+                    }
+                }
+                tracing::info!("Read string: {:?}", String::from_utf8_lossy(&data));
+            }
+
+            if event.is_writable() {
+                tracing::info!("writing: {:?}", data);
+                stream.write_all(&data)?;
+            }
+        }
+
+        // check for shutdown notice
+        match shutdown_rx.try_recv() {
+            Err(TryRecvError::Disconnected) => {
+                // this should only happen if the other end of the
+                // channel is closed
+                tracing::error!("Error receiving shutdown notice, disconnected");
+                break;
+            }
+            Err(TryRecvError::Empty) => {}
+            Ok(()) => {
+                tracing::info!("Shutdown notice received");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/imputio-utils/Cargo.toml
+++ b/imputio-utils/Cargo.toml
@@ -10,6 +10,5 @@ tracing.workspace=true
 thiserror.workspace=true
 imputio.workspace=true
 
-
 [features]
 delay-delete=[]

--- a/imputio/Cargo.toml
+++ b/imputio/Cargo.toml
@@ -9,9 +9,9 @@ futures-lite.workspace=true
 flume.workspace=true
 tracing.workspace=true
 thiserror.workspace=true
+mio.workspace=true
+slab.workspace=true
 rand = {version = "0.9.0", optional=true}
 
 [features]
-default=[]
 fairness=["dep:rand"]
-

--- a/imputio/src/io/epoll.rs
+++ b/imputio/src/io/epoll.rs
@@ -1,0 +1,213 @@
+use mio::{event::Event, net::TcpListener, Events, Interest, Poll as EPoller, Token};
+use slab::Slab;
+use std::{
+    collections::HashMap,
+    net::TcpListener as StdTcpListener,
+    os::fd::{AsRawFd, RawFd},
+};
+
+use super::PollError;
+
+#[derive(Debug)]
+pub struct PollCfg {
+    event_size: usize,
+}
+
+impl Default for PollCfg {
+    fn default() -> Self {
+        Self { event_size: 256 }
+    }
+}
+
+type Result<T> = std::result::Result<T, PollError>;
+
+#[derive(Debug)]
+pub enum Operation {
+    /// Register a file descriptor as a
+    /// [`mio::unix::SourceFd`]
+    RegistrationFdAdd {
+        fd: RawFd,
+        interest: Interest,
+        notify: Option<flume::Sender<Event>>,
+    },
+    /// Register a std lib [`std::net::TcpListener`]
+    /// with the epoll actor
+    RegistrationTcpAdd {
+        fd: StdTcpListener,
+        interest: Interest,
+        notify: Option<flume::Sender<Event>>,
+    },
+    /// Use the raw file descriptor to modify
+    /// either a registered TCP socket or a
+    /// unix FD
+    ModifyRegistration {
+        fd: RawFd,
+        interest: Interest,
+        notify: Option<flume::Sender<Event>>,
+    },
+    DeleteRegistration {
+        fd: RawFd,
+    },
+}
+
+unsafe impl Sync for Operation {}
+unsafe impl Send for Operation {}
+
+const RW_INTERESTS: Interest = Interest::READABLE
+    .add(Interest::WRITABLE)
+    .add(Interest::PRIORITY);
+
+pub struct Poller {
+    poller: EPoller,
+    events: Events,
+    ids: HashMap<RawFd, (usize, Option<flume::Sender<Event>>)>,
+    tokens: Slab<Operation>,
+}
+
+impl Poller {
+    pub fn new(cfg: PollCfg) -> Result<Self> {
+        let poller: mio::Poll = mio::Poll::new()?;
+        let events = Events::with_capacity(cfg.event_size);
+
+        Ok(Self {
+            poller,
+            events,
+            tokens: Slab::new(),
+            ids: HashMap::new(),
+        })
+    }
+
+    pub fn poll(&mut self) -> Result<()> {
+        self.poller
+            .poll(&mut self.events, Some(std::time::Duration::from_millis(10)))?;
+
+        for event in self.events.iter() {
+            if let Some(op) = self.tokens.get(event.token().0) {
+                match op {
+                    Operation::RegistrationFdAdd { notify, .. } => {
+                        tracing::debug!("Adding modified event! {event:?}");
+
+                        if let Some(notify) = notify {
+                            if let Err(e) = notify.send(event.clone()) {
+                                tracing::error!("Error sending to user-supplied notifier {e:}");
+                            }
+                        }
+                    }
+                    Operation::ModifyRegistration { .. } => todo!(),
+                    Operation::DeleteRegistration { .. } => todo!(),
+                    Operation::RegistrationTcpAdd { notify, .. } => {
+                        tracing::debug!("Adding tcp socket! {event:?}");
+
+                        if let Some(notify) = notify {
+                            if let Err(e) = notify.send(event.clone()) {
+                                tracing::error!("Error sending to user-supplied notifier {e:}");
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn push_token_entry(&mut self, op: Operation) -> Result<()> {
+        match op {
+            Operation::RegistrationFdAdd {
+                fd,
+                interest,
+                notify,
+            } => {
+                let id = if let Some((id, existing_notify)) = self.ids.get(&fd) {
+                    // FIXME!! dont use direct index access lest this panic
+                    let token = &mut self.tokens[*id];
+                    *token = Operation::RegistrationFdAdd {
+                        fd,
+                        interest,
+                        notify: existing_notify.clone(),
+                    };
+                    *id
+                } else {
+                    let new_id = self.tokens.vacant_entry().key();
+                    self.ids.insert(fd, (new_id, None));
+                    self.tokens.insert(Operation::RegistrationFdAdd {
+                        fd,
+                        interest,
+                        notify,
+                    });
+                    new_id
+                };
+
+                self.poller.registry().register(
+                    &mut mio::unix::SourceFd(&fd),
+                    Token(id),
+                    RW_INTERESTS,
+                )?;
+            }
+            Operation::ModifyRegistration {
+                fd,
+                interest,
+                notify,
+            } => {
+                let id = if let Some((id, existing_notify)) = self.ids.get(&fd) {
+                    // FIXME!! dont use direct index access lest this panic
+                    let token = &mut self.tokens[*id];
+                    *token = Operation::ModifyRegistration {
+                        fd,
+                        interest,
+                        notify: existing_notify.clone(),
+                    };
+                    *id
+                } else {
+                    let new_id = self.tokens.vacant_entry().key();
+                    self.ids.insert(fd, (new_id, None));
+                    self.tokens.insert(Operation::ModifyRegistration {
+                        fd,
+                        interest,
+                        notify: notify.clone(),
+                    });
+                    new_id
+                };
+
+                if let Some(notify) = notify {
+                    self.ids.insert(fd, (id, Some(notify)));
+                }
+            }
+            Operation::DeleteRegistration { .. } => todo!(),
+            Operation::RegistrationTcpAdd {
+                fd,
+                interest,
+                notify,
+            } => {
+                let raw_fd = fd.as_raw_fd();
+                let new_event_id = if let Some((id, existing_notify)) = self.ids.get(&raw_fd) {
+                    // TODO!! dont use direct index access left this panic
+                    let token = &mut self.tokens[*id];
+                    *token = Operation::RegistrationTcpAdd {
+                        fd: fd.try_clone()?,
+                        interest,
+                        notify: existing_notify.clone(),
+                    };
+                    *id
+                } else {
+                    let new_id = self.tokens.vacant_entry().key();
+                    self.ids.insert(raw_fd, (new_id, notify.clone()));
+                    self.tokens.insert(Operation::RegistrationTcpAdd {
+                        fd: fd.try_clone()?,
+                        interest,
+                        notify,
+                    });
+                    new_id
+                };
+
+                let mut mio_tcp = TcpListener::from_std(fd);
+
+                self.poller
+                    .registry()
+                    .register(&mut mio_tcp, Token(new_event_id), RW_INTERESTS)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/imputio/src/io/mod.rs
+++ b/imputio/src/io/mod.rs
@@ -1,0 +1,156 @@
+//! actor / handle impl backed by
+//! the epoll kernel datastructure
+//! as provided by mio dependency
+
+mod epoll;
+
+pub use epoll::{Operation, PollCfg, Poller};
+
+use tracing::instrument;
+
+#[derive(thiserror::Error, Debug)]
+pub enum PollError {
+    #[error("Resource exhaustion")]
+    ResourceExhaustion,
+    #[error("Actor error {0}")]
+    ActorError(String),
+    #[error("Actor receive error {0}")]
+    ActorRcvError(#[from] flume::RecvError),
+    #[error("Actor send error {0}")]
+    ActorSendError(#[from] flume::SendError<IoOp>),
+    #[error("Io error")]
+    IoError(#[from] std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, PollError>;
+
+#[derive(Debug)]
+pub enum IoOp {
+    Submit { op: Operation },
+    Poll,
+    Process,
+    PollAndProcess,
+}
+
+unsafe impl Sync for IoOp {}
+unsafe impl Send for IoOp {}
+
+#[derive(Clone)]
+pub struct PollHandle {
+    tx: flume::Sender<IoOp>,
+}
+
+impl std::fmt::Debug for PollHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PollHandle").finish()
+    }
+}
+
+impl PollHandle {
+    pub fn new(tx: flume::Sender<IoOp>) -> Self {
+        Self { tx }
+    }
+
+    pub fn initialize(poll_cfg: Option<PollCfg>) -> (PollerActor, PollHandle) {
+        let (tx, rx) = flume::unbounded();
+        let poll_ring = PollerActor::new(rx, poll_cfg);
+        let handle = Self::new(tx);
+        (poll_ring, handle)
+    }
+
+    pub fn submit_op(&self, op: Operation) -> Result<()> {
+        let op = IoOp::Submit { op };
+        self.tx
+            .send(op)
+            .inspect_err(|e| tracing::error!("submit op failure {e:}"))?;
+
+        Ok(())
+    }
+
+    pub fn poll(&self) -> Result<()> {
+        self.tx
+            .send(IoOp::Poll)
+            .inspect_err(|e| tracing::error!("Poll op failure {e:}"))?;
+
+        Ok(())
+    }
+
+    pub fn poll_and_process(&self) -> Result<()> {
+        self.tx
+            .send(IoOp::PollAndProcess)
+            .inspect_err(|e| tracing::error!("PollAndProcess op failure {e:}"))?;
+
+        Ok(())
+    }
+
+    pub fn process(&self) -> Result<()> {
+        self.tx
+            .send(IoOp::Process)
+            .inspect_err(|e| tracing::error!("Process op failure {e:}"))?;
+
+        Ok(())
+    }
+}
+
+pub struct PollerActor {
+    receiver: flume::Receiver<IoOp>,
+    poller: Poller,
+}
+
+unsafe impl Send for PollerActor {}
+unsafe impl Sync for PollerActor {}
+
+impl std::fmt::Debug for PollerActor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PollerActor").finish()
+    }
+}
+
+impl PollerActor {
+    #[instrument]
+    pub fn new(receiver: flume::Receiver<IoOp>, poll_cfg: Option<PollCfg>) -> Self {
+        tracing::debug!("New io actor created");
+        Self {
+            poller: Poller::new(poll_cfg.unwrap_or_default()).expect("Unable to create new poller"),
+            receiver,
+        }
+    }
+
+    #[instrument]
+    pub fn run(mut self) {
+        while let Ok(event) = self.receiver.recv() {
+            match event {
+                IoOp::Submit { op } => self.submit(op).ok(),
+                IoOp::Poll => self.poll().ok(),
+                IoOp::Process => self.process().ok(),
+                IoOp::PollAndProcess => self.poll_and_process().ok(),
+            };
+        }
+    }
+
+    #[instrument]
+    fn submit(&mut self, op: Operation) -> Result<()> {
+        tracing::debug!("Received event");
+        self.poller.push_token_entry(op)?;
+        Ok(())
+    }
+
+    #[instrument]
+    fn poll_and_process(&mut self) -> Result<()> {
+        self.poll()?;
+        self.process()?;
+        Ok(())
+    }
+
+    #[instrument]
+    fn poll(&mut self) -> Result<()> {
+        self.poller.poll()?;
+        Ok(())
+    }
+
+    #[instrument]
+    fn process(&mut self) -> Result<()> {
+        // FIXME: process step only needed for io_uring
+        Ok(())
+    }
+}

--- a/imputio/src/lib.rs
+++ b/imputio/src/lib.rs
@@ -2,6 +2,7 @@
 //! intended for educational purposes
 
 mod executor;
+mod io;
 mod runtime;
 mod task;
 #[macro_use]
@@ -16,6 +17,16 @@ use std::sync::{LazyLock, Mutex};
 // FIXME can we make this lockless / wait free while also being global?
 pub static EXECUTOR: LazyLock<Mutex<Executor>> =
     LazyLock::new(|| Mutex::new(Executor::initialize()));
+
+/// Main entry point for running futures within an imputio runtime
+/// without configuring the runtime with additional params
+pub fn rt_entry<F, R>(fut: F) -> R
+where
+    F: std::future::Future<Output = R> + Send + 'static,
+    R: Send + 'static,
+{
+    ImputioRuntime::<Executor>::new().block_on(fut)
+}
 
 /// Priority is used to enqueue tasks onto priority queues
 /// note that idx 0 is reserved for system priority work


### PR DESCRIPTION
Add `epoll`-backed io handle for registering and polling simple objects within the `imputio` runtime. Adds support for TCP sockets and simple file descriptors. Uses the dependency `mio`; may later add support for `poller` as well.