### PR TITLE
Add multithreaded executor and leverage `ArcSwap`

### DIFF
--- a/imputio/Cargo.toml
+++ b/imputio/Cargo.toml
@@ -14,7 +14,6 @@ slab.workspace=true
 rand = {version = "0.9.0", optional=true}
 derive_builder = "0.20.2"
 arc-swap = "1.7.1"
-once_cell = "1.20.3"
 core_affinity = "0.8.1"
 
 [features]

--- a/imputio/Cargo.toml
+++ b/imputio/Cargo.toml
@@ -13,6 +13,9 @@ mio.workspace=true
 slab.workspace=true
 rand = {version = "0.9.0", optional=true}
 derive_builder = "0.20.2"
+arc-swap = "1.7.1"
+once_cell = "1.20.3"
+core_affinity = "0.8.1"
 
 [features]
 fairness=["dep:rand"]

--- a/imputio/src/executor/handle.rs
+++ b/imputio/src/executor/handle.rs
@@ -116,7 +116,7 @@ impl ExecHandleCoordinator {
     }
 
     pub fn submit_io_op(&self, op: Operation) -> Result<()> {
-        let index = (self.index.load(Ordering::SeqCst) + 1).wrapping_rem(self.handles.len());
+        let index = (self.index.load(Ordering::SeqCst) + 1) % self.handles.len();
         self.index.store(index, Ordering::SeqCst);
 
         self.handles[index].submit_io_op(op)
@@ -206,7 +206,7 @@ impl ExecHandle {
             .inspect_err(|e| tracing::error!("submit io op failure {e:}"))
             .ok();
 
-        Ok(rx.recv()??)
+        rx.recv()?
     }
 }
 

--- a/imputio/src/executor/handle.rs
+++ b/imputio/src/executor/handle.rs
@@ -1,13 +1,20 @@
-use std::{collections::VecDeque, future::Future, pin::Pin};
+use std::{
+    collections::VecDeque,
+    future::Future,
+    pin::Pin,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 #[cfg(feature = "fairness")]
 use rand::{self, Rng};
 
 use crate::{
-    io::{Operation, PollCfg, PollError, PollHandle},
+    io::{Operation, PollError, PollHandle},
     task::{ImputioTask, ImputioTaskHandle},
     Priority,
 };
+
+use super::{ExecConfig, ThreadConfig};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ExecError {
@@ -21,30 +28,187 @@ pub enum ExecError {
     IoPoller(#[from] PollError),
 }
 
-impl crate::RuntimeScheduler for ExecHandle {
-    fn spawn<F, T>(&self, fut: F) -> ImputioTaskHandle<T>
+type Result<T> = std::result::Result<T, ExecError>;
+type Reply<T> = flume::Sender<T>;
+
+/// [`Transaction`] enum defines the [`Executor`]
+/// actor methods a handle ([`ExecHandle`]) to
+/// an [`Executor`] object can execute
+pub enum Transaction {
+    Spawn {
+        task: ImputioTask,
+    },
+    Poll,
+    SubmitIoOp {
+        op: Operation,
+        reply: Reply<Result<()>>,
+    },
+}
+
+/// The [`ExecHandleCoordinator`] provides a simple, global
+/// entry point to a series of handles ([`ExecHandle`]) that
+/// can be used to send  [`Transaction`] requests to one or
+/// more [`Executor`] objects executing on their own thread.
+/// Each [`Executor`] additionally spawns another thread to
+/// run it's own I/O (epoll) actor, which is used to enqueue
+/// I/O futures onto separate from the general purpose task
+/// queue that each [`Executor`] actor is responsible for
+/// polling
+pub struct ExecHandleCoordinator {
+    handles: Vec<ExecHandle>,
+    index: AtomicUsize,
+}
+
+impl ExecHandleCoordinator {
+    pub fn new() -> Self {
+        let (tx, _rx) = flume::bounded(1);
+        Self {
+            handles: vec![ExecHandle::new(tx)],
+            index: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn initialize(exec_cfg: ExecConfig) -> Self {
+        let handles = exec_cfg
+            .exec_thread_config
+            .iter()
+            .filter_map(|(exec_handle_cfg, io_poller_cfg)| {
+                ExecHandle::initialize(exec_handle_cfg.clone(), io_poller_cfg.clone()).ok()
+            })
+            .collect::<Vec<_>>();
+
+        Self {
+            handles,
+            index: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn spawn<F, T>(&self, fut: F, priority: Priority) -> ImputioTaskHandle<T>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        ExecHandle::spawn(self, fut, Priority::Medium)
+        let index = (self.index.load(Ordering::SeqCst) + 1) % self.handles.len();
+        self.index.store(index, Ordering::SeqCst);
+
+        self.handles[index].spawn(fut, priority)
     }
 
-    fn poll(&self) {
-        ExecHandle::poll(self)
-    }
-
-    fn priority_spawn<F, T>(&self, fut: F, priority: Priority) -> ImputioTaskHandle<T>
+    /// Skips enqueuing the future to task queue, creates a new task and blocks until
+    /// it completes
+    pub(crate) fn spawn_blocking<F, T>(&self, fut: F) -> T
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        ExecHandle::spawn(self, fut, priority)
+        // TODO spawn blocking only on local thread
+        let spawn_fut: Pin<Box<dyn Future<Output = T> + Send>> = Box::pin(fut);
+        // note: priority for blocking tasks does not apply
+        let task = ImputioTask::new(spawn_fut, Priority::High);
+        task.run()
+    }
+
+    pub fn poll(&self) {
+        let index = (self.index.load(Ordering::SeqCst) + 1) % self.handles.len();
+        self.index.store(index, Ordering::SeqCst);
+
+        self.handles[index].poll();
+    }
+
+    pub fn submit_io_op(&self, op: Operation) -> Result<()> {
+        let index = (self.index.load(Ordering::SeqCst) + 1).wrapping_rem(self.handles.len());
+        self.index.store(index, Ordering::SeqCst);
+
+        self.handles[index].submit_io_op(op)
     }
 }
 
-type Result<T> = std::result::Result<T, ExecError>;
-type Reply<T> = flume::Sender<T>;
+/// Defines handle to the [`Executor`]
+/// actor
+#[derive(Clone)]
+struct ExecHandle {
+    tx: flume::Sender<Transaction>,
+}
+
+impl ExecHandle {
+    pub(crate) fn new(tx: flume::Sender<Transaction>) -> Self {
+        Self { tx }
+    }
+
+    fn initialize(exec_cfg: ThreadConfig, poller_cfg: ThreadConfig) -> Result<Self> {
+        let (tx, rx) = flume::unbounded();
+        let handle = Self::new(tx);
+
+        let exec = Executor::initialize(rx, poller_cfg)?;
+
+        std::thread::Builder::new()
+            .name(exec_cfg.thread_name)
+            .stack_size(exec_cfg.stack_size)
+            //.no_hooks()
+            .spawn(move || {
+                if let Some(core) = exec_cfg.core_id {
+                    core_affinity::set_for_current(core);
+                }
+                exec.run()
+            })?;
+        Ok(handle)
+    }
+
+    pub fn spawn<F, T>(&self, fut: F, priority: Priority) -> ImputioTaskHandle<T>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (tx, rx) = flume::unbounded();
+
+        let spawn_fut = Box::pin(async move {
+            let res = fut.await;
+            tx.send(res).ok();
+        });
+
+        let task = ImputioTask::new(spawn_fut, priority);
+
+        let op = Transaction::Spawn { task };
+        self.tx
+            .send(op)
+            .inspect_err(|e| tracing::error!("spawn op failure {e:}"))
+            .ok();
+
+        ImputioTaskHandle { receiver: rx }
+    }
+
+    /// Skips enqueuing the future to task queue, creates a new task and blocks until
+    /// it completes
+    #[allow(unused)] // TODO spawn blocking only on local thread
+    pub(crate) fn spawn_blocking<F, T>(&self, fut: F) -> T
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let spawn_fut: Pin<Box<dyn Future<Output = T> + Send>> = Box::pin(fut);
+        // note: priority for blocking tasks does not apply
+        let task = ImputioTask::new(spawn_fut, Priority::High);
+        task.run()
+    }
+
+    pub fn poll(&self) {
+        self.tx
+            .send(Transaction::Poll)
+            .inspect_err(|e| tracing::error!("poll op failure {e:}"))
+            .ok();
+    }
+
+    pub fn submit_io_op(&self, op: Operation) -> Result<()> {
+        let (reply, rx) = flume::bounded(1);
+
+        self.tx
+            .send(Transaction::SubmitIoOp { op, reply })
+            .inspect_err(|e| tracing::error!("submit io op failure {e:}"))
+            .ok();
+
+        Ok(rx.recv()??)
+    }
+}
 
 /// Simple "priority" executor with higher priority
 /// queues dequeuing tasks first. Simple io operations
@@ -58,17 +222,31 @@ pub struct Executor {
 }
 
 impl Executor {
-    fn initialize(rx: flume::Receiver<Transaction>, poll_cfg: Option<PollCfg>) -> Self {
-        tracing::debug!("Running executor thread");
+    fn initialize(rx: flume::Receiver<Transaction>, cfg: ThreadConfig) -> Result<Self> {
+        tracing::debug!(
+            "Running executor actor thread id: {:?}, name  {:?}",
+            std::thread::current().id(),
+            std::thread::current().name()
+        );
 
         // FIXME: allow runtime with build options to specify size of poll cfg event queue
-        let (actor, handle) = PollHandle::initialize(poll_cfg);
-        std::thread::spawn(move || actor.run());
-        Self {
+        let (actor, handle) = PollHandle::initialize(cfg.poll_cfg)?;
+
+        std::thread::Builder::new()
+            .name(cfg.thread_name)
+            .stack_size(cfg.stack_size)
+            //.no_hooks()
+            .spawn(move || {
+                if let Some(core) = cfg.core_id {
+                    core_affinity::set_for_current(core);
+                }
+                actor.run()
+            })?;
+        Ok(Self {
             poll_handle: handle,
             rx,
             tasks: [(); 5].map(|_| VecDeque::new()),
-        }
+        })
     }
 
     fn spawn(&mut self, task: ImputioTask) {
@@ -129,88 +307,5 @@ impl Executor {
                 }
             };
         }
-    }
-}
-
-pub enum Transaction {
-    Spawn {
-        task: ImputioTask,
-    },
-    Poll,
-    SubmitIoOp {
-        op: Operation,
-        reply: Reply<Result<()>>,
-    },
-}
-
-#[derive(Clone)]
-pub struct ExecHandle {
-    tx: flume::Sender<Transaction>,
-}
-
-impl ExecHandle {
-    fn new(tx: flume::Sender<Transaction>) -> Self {
-        Self { tx }
-    }
-
-    pub fn initialize(poll_cfg: Option<PollCfg>) -> ExecHandle {
-        let (tx, rx) = flume::unbounded();
-        let exec = Executor::initialize(rx, poll_cfg);
-        let handle = Self::new(tx);
-        std::thread::spawn(move || exec.run());
-        handle
-    }
-
-    pub fn spawn<F, T>(&self, fut: F, priority: Priority) -> ImputioTaskHandle<T>
-    where
-        F: Future<Output = T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let (tx, rx) = flume::unbounded();
-
-        let spawn_fut = Box::pin(async move {
-            let res = fut.await;
-            tx.send(res).ok();
-        });
-
-        let task = ImputioTask::new(spawn_fut, priority);
-
-        let op = Transaction::Spawn { task };
-        self.tx
-            .send(op)
-            .inspect_err(|e| tracing::error!("spawn op failure {e:}"))
-            .ok();
-
-        ImputioTaskHandle { receiver: rx }
-    }
-
-    /// Skips enqueuing the future to task queue, creates a new task and blocks until
-    /// it completes
-    pub(crate) fn spawn_blocking<F, T>(&self, fut: F, priority: Priority) -> T
-    where
-        F: Future<Output = T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let spawn_fut: Pin<Box<dyn Future<Output = T> + Send>> = Box::pin(fut);
-        let task = ImputioTask::new(spawn_fut, priority);
-        task.run()
-    }
-
-    pub fn poll(&self) {
-        self.tx
-            .send(Transaction::Poll)
-            .inspect_err(|e| tracing::error!("poll op failure {e:}"))
-            .ok();
-    }
-
-    pub fn submit_io_op(&self, op: Operation) -> Result<()> {
-        let (reply, rx) = flume::bounded(1);
-
-        self.tx
-            .send(Transaction::SubmitIoOp { op, reply })
-            .inspect_err(|e| tracing::error!("submit io op failure {e:}"))
-            .ok();
-
-        rx.recv().expect("Unable to submit io op")
     }
 }

--- a/imputio/src/io/epoll.rs
+++ b/imputio/src/io/epoll.rs
@@ -8,7 +8,7 @@ use std::{
 
 use super::PollError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PollCfg {
     event_size: usize,
 }

--- a/imputio/src/macros.rs
+++ b/imputio/src/macros.rs
@@ -11,9 +11,6 @@ macro_rules! spawn {
 #[macro_export]
 macro_rules! spawn_blocking {
     ($fut:expr) => {
-        spawn_blocking!($fut, $crate::Priority::High)
-    };
-    ($fut:expr, $priority:expr) => {
-        $crate::spawn_blocking($fut, $priority)
+        $crate::spawn_blocking($fut)
     };
 }

--- a/imputio/src/runtime.rs
+++ b/imputio/src/runtime.rs
@@ -39,7 +39,7 @@ pub struct ImputioRuntime {
     _num_exec_threads: usize,
     exec_thread_id: ThreadId,
     shutdown: (flume::Sender<()>, flume::Receiver<()>),
-    // TODO: allow spawning multiple exec threads
+    // TODO: allow optional config to pin certain threads to cores
     _core_ids: Vec<CoreId>,
 }
 
@@ -272,16 +272,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_spawn_in_block_on_ctx() {
         ImputioRuntime::new().block_on(async move {
             // count does not matter here as this test
             // is checking for panics to arise when expected
             let ex = ExampleTask { count: 0 };
 
-            // spawning a blocking task within the block_on context should panic
-            // if we use #[should_panic], because there is a single global executor
-            // object, that can cause other tests to fail
             let result = std::panic::catch_unwind(|| spawn_blocking!(ex));
             assert!(result.is_err());
         });


### PR DESCRIPTION
PR adds logic to make the executor multi-threaded. Additionally leveraged `ArcSwap` to allow for configuring the executor with runtime-provided build args while remaining lock free. This change works the executor into the builder pattern for the `ImputioRuntime` object added in PR #8 . More follow on work is needed to leverage the config options passed from builder to executor threads, currently all examples etc. use default config options. 