### PR TITLE
Replace default allocator with jemalloc to handle memory leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["nand-nor <a13xandra.cliff0rd@gmail.com>"]
 
 [workspace.dependencies]
 futures-lite = "2.6.0"
-flume = {version="0.11.1", features=["eventual-fairness", "async", "select"]}
+flume = {version="0.11.1"}
 tracing = "0.1.41"
 thiserror = "2.0.11"
 mio = {version="1.0.3", features=["net", "os-ext", "os-poll"]}
@@ -16,3 +16,9 @@ slab = "0.4.9"
 core_affinity = "0.8.1"
 imputio = { path = "./imputio"}
 imputio-utils= {path="./imputio-utils"}
+tikv-jemallocator = {version="0.6.0"}
+
+[profile.bench]
+debug = true
+lto = true
+codegen-units = 1

--- a/benches/rt_cfg.rs
+++ b/benches/rt_cfg.rs
@@ -110,10 +110,7 @@ fn test_simple_rt(criterion: &mut Criterion) {
     rt.run();
 
     criterion.bench_function("simple_rt", |b| {
-        b.iter(|| {
-            rt.clone()
-                .block_on(async move { spawn!(event_bus_example()) })
-        })
+        b.iter(|| rt.block_on(async move { spawn!(event_bus_example()) }))
     });
 }
 
@@ -124,10 +121,7 @@ fn test_default_rt(criterion: &mut Criterion) {
     rt.run();
 
     criterion.bench_function("default_rt", |b| {
-        b.iter(|| {
-            rt.clone()
-                .block_on(async move { spawn!(event_bus_example()) })
-        })
+        b.iter(|| rt.block_on(async move { spawn!(event_bus_example()) }))
     });
 }
 
@@ -170,10 +164,7 @@ fn test_complex_rt(criterion: &mut Criterion) {
     rt.run();
 
     criterion.bench_function("complex_rt", |b| {
-        b.iter(|| {
-            rt.clone()
-                .block_on(async move { spawn!(event_bus_example()) })
-        })
+        b.iter(|| rt.block_on(async move { spawn!(event_bus_example()) }))
     });
 }
 

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -56,7 +56,7 @@ fn test_simple1(criterion: &mut Criterion) {
     rt.run();
 
     criterion.bench_function("simple1", |b| {
-        b.iter(|| rt.clone().block_on(async move { spawn!(counter1()) }))
+        b.iter(|| rt.block_on(async move { spawn!(counter1()) }))
     });
 }
 
@@ -70,7 +70,7 @@ fn test_simple2(criterion: &mut Criterion) {
     rt.run();
 
     criterion.bench_function("simple2", |b| {
-        b.iter(|| rt.clone().block_on(async move { spawn!(counter2()) }))
+        b.iter(|| rt.block_on(async move { spawn!(counter2()) }))
     });
 }
 

--- a/imputio-utils/Cargo.toml
+++ b/imputio-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 futures-lite.workspace=true
-flume.workspace=true
+flume= {workspace=true, features=["async"]}
 tracing.workspace=true
 thiserror.workspace=true
 imputio.workspace=true

--- a/imputio/Cargo.toml
+++ b/imputio/Cargo.toml
@@ -15,9 +15,13 @@ rand = {version = "0.9.0", optional=true}
 derive_builder = "0.20.2"
 arc-swap = "1.7.1"
 core_affinity.workspace=true
+tikv-jemallocator = {workspace = true, optional=true}
 
 [dev-dependencies]
 libc="*"
 
 [features]
+default=["tikv-jemallocator", "io"]
 fairness=["dep:rand"]
+tikv-jemallocator=["dep:tikv-jemallocator"]
+io=[]

--- a/imputio/src/executor/mod.rs
+++ b/imputio/src/executor/mod.rs
@@ -64,7 +64,7 @@ impl Default for ThreadConfig {
     fn default() -> Self {
         Self {
             thread_name: "imputio-thread".to_string(),
-            stack_size: u16::MAX as usize,
+            stack_size: 131072,
             core_id: None,
             parking: Some(10),
         }


### PR DESCRIPTION
This PR adds the ability to build with tikv's jemalloc allocator, which is enabled by default. However users can still opt to use the default allocator if desired, by disabling default features.  

Additionally, this PR adds the following:
- increases the default thread stack size to 2^16. Users should note that although they can specify something smaller, debug builds with jemalloc allocator may run into thread stack overflow issues for the threads spawned for executor and io polling
- makes io polling a feature that is enabled by default, but that can be disabled for simpler runtime needs